### PR TITLE
support work without an index file (take workspace packages)

### DIFF
--- a/haros/haros.py
+++ b/haros/haros.py
@@ -124,7 +124,7 @@ def parse_arguments(argv):
                              help = "visualisation host " \
                                     "(default: \"localhost:8080\")")
     parser_full.add_argument("-p", "--package-index", dest = "pkg_filter",
-                             help = "package index file")
+                            help = "package index file (default: packages in current catkin workspace)")
     group = parser_full.add_mutually_exclusive_group()
     group.add_argument("-w", "--whitelist", nargs = "*", dest = "whitelist",
                        help = "execute only these plugins")
@@ -221,8 +221,6 @@ def command_analyse(args):
            if args.pkg_filter and os.path.isfile(args.pkg_filter) \
            else os.path.join(HAROS_DIR, "index.yaml")
     _log.debug("Package index file %s", path)
-    if not os.path.isfile(path):
-        raise RuntimeError("There is no package index file. Aborting.")
     dataman.index_source(path, REPOSITORY_DIR, args.use_repos)
     if not dataman.packages:
         _log.warning("There are no packages to analyse.")


### PR DESCRIPTION
I added a mode of operation when the packages to scan are picked from the current workspace (instead of being read from an index file).  With this patch, Haros operates as before if the "-p" option has been given.  If the option is not there, or the default/given index file is empty, then the tool checks if is executed from the root of a catkin workspace and searches for all contained packages in `src/`.

This patch should help running Haros on packages that don't know about it, ultimately in ROS continuous integration. 