### PR TITLE
add general option -C to change a directory before running

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ After initialisation, you still need to install some analysis tools that HAROS
 uses behind the curtains. Install these *$dependencies$* with the following commands.
 
 ```bash
-sudo apt-get install python-pip
-pip install --upgrade pip
-sudo pip install radon
-sudo pip install lizard
 sudo apt-get install cppcheck
 ```
 

--- a/haros/data_manager.py
+++ b/haros/data_manager.py
@@ -596,7 +596,7 @@ class DataManager(object):
         missing = []
         pkg_list = self._read_launch_listing(data.get("launch"))
         pkg_list.extend(data.get("packages", []))
-        if not pkg_list and os.path.isfile("src/CMakeLists.txt"):
+        if not pkg_list:
             _log.info("Harvesting packages from catkin workspace")
             pkg_list = RosPack.get_instance(".").list()
         pkg_list = set(pkg_list)

--- a/haros/haros.py
+++ b/haros/haros.py
@@ -111,6 +111,8 @@ def parse_arguments(argv, source_runner):
             description="ROS quality assurance.")
     parser.add_argument("--debug", action = "store_true",
                         help = "set debug logging")
+    parser.add_argument("-C", dest = "dir",
+            help = "change current directory to DIR before running")
     subparsers = parser.add_subparsers()
 
     parser_init = subparsers.add_parser("init")
@@ -124,7 +126,7 @@ def parse_arguments(argv, source_runner):
                              help = "visualisation host " \
                                     "(default: \"localhost:8080\")")
     parser_full.add_argument("-p", "--package-index", dest = "pkg_filter",
-                            help = "package index file (default: packages in current catkin workspace)")
+        help = "package index file (default: workspace packages below current dir)")
     group = parser_full.add_mutually_exclusive_group()
     group.add_argument("-w", "--whitelist", nargs = "*", dest = "whitelist",
                        help = "execute only these plugins")
@@ -137,7 +139,7 @@ def parse_arguments(argv, source_runner):
                                 action = "store_true",
                                 help = "use repositories")
     parser_analyse.add_argument("-p", "--package-index", dest = "pkg_filter",
-                                help = "package index file")
+        help = "package index file (default: workspace packages below current dir)")
     group = parser_analyse.add_mutually_exclusive_group()
     group.add_argument("-w", "--whitelist", nargs = "*", dest = "whitelist",
                        help="execute only these plugins")
@@ -317,10 +319,14 @@ def main(argv = None, source_runner = False):
                             level = logging.DEBUG)
     else:
         logging.basicConfig(level = logging.WARNING)
+
     try:
+        if args.dir:
+            os.chdir(args.dir)
         _log.info("Executing selected command.")
         args.func(args)
         return 0
+
     except RuntimeError as err:
         _log.error(str(err))
         return 1

--- a/haros/haros.py
+++ b/haros/haros.py
@@ -320,6 +320,7 @@ def main(argv = None, source_runner = False):
     else:
         logging.basicConfig(level = logging.WARNING)
 
+    original_path = os.getcwd()
     try:
         if args.dir:
             os.chdir(args.dir)
@@ -330,3 +331,6 @@ def main(argv = None, source_runner = False):
     except RuntimeError as err:
         _log.error(str(err))
         return 1
+
+    finally:
+        os.chdir(original_path)

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,11 @@ setup(
     packages        = find_packages(),
     entry_points    = {"console_scripts": ["haros = haros.haros:main"]},
     package_data    = {"haros": extra_files},
+    install_requires = [
+          'pyyaml',
+          'lizard',
+          'radon',
+          'rospkg'
+      ],
     zip_safe        = True
 )


### PR DESCRIPTION
I added a top-level option `-C` that allows changing the current directory before running haros.  This plays well with the new functionality of searching packages in the sub-tree of current directory (makes it easy to analyze only packages from a particular directory).  For this reason, I also removed the safety check whether haros is run from the root of a work space (now we are fine to run it also from deeper directories).

Now if you want to analyze a single package only, you can do it without creating an index file, for example, as follows:

```
 haros -C src/my_repository_checkout/my_package/ analyse
```

The help messages are also updated. 

The option is implemented at top level so it should also work with other commands, when it makes sense (for instance it likely works with export, but I did not check).