### PR TITLE
Support for Multi-Project Analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0] - 2017-10-31
+### Added
+- Concept of project, more or less equivalent to an index file.
+- `-a` option for `analyse` and `full` commands, to import an existing analysis database.
+
+### Changed
+- `-d` option from viz is now `-t` for consistency with `analyse` and `full` commands.
+- Directory structure for viz and Haros data.
+- Viz dashboard now allows selection of displayed project.
+
 ## [0.3.0] - 2017-10-25
 ### Added
 - Change log.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ python setup.py install
 After installation, you should be able to run the command `haros` in your terminal
 from anywhere.
 
-### Prerequisites
+### Requirements
 
 Before you can actually run analyses with HAROS, you need to perform some
 initialisation operations. These operations include downloading a basic set of
@@ -111,7 +111,8 @@ Here is a basic example to help you get started with HAROS.
 Additional examples should be added in a future update.
 
 HAROS works with the concept of **index files**.
-These files tell HAROS which packages you want to analyse.
+These files are more or less an equivalent to a project description,
+and they tell HAROS which packages you want to analyse.
 For this basic example, you should have the packages installed,
 and with available source code.
 If you run `rospack find my_package` and it returns the location
@@ -152,6 +153,20 @@ The `-p` option lets you specify an index file of your own, instead of using the
 When the analysis finishes, HAROS should start a visualisation server and your web browser
 on the appropriate page. To exit, just close your browser and press `Enter` on the terminal.
 
+If you want to analyse several projects, or groups of packages, it is
+recommended to create an index file for each project, and define a project
+name as well. This way, HAROS will store analysis results separately.
+Example:
+
+```yaml
+%YAML 1.1
+---
+project: my_robot
+packages:
+    - package1
+    - package2
+```
+
 Below you can find the basic commands that HAROS provides.
 
 ### haros init
@@ -170,6 +185,10 @@ Runs analysis with the list of packages found within the default index file
 #### haros analyse -p INDEX_FILE
 
 Uses the given index file to run the analysis, instead of the default one.
+
+#### haros analyse -a ANALYSIS_DB_FILE
+
+Uses the given analysis database to run the analysis. New analysis records are added to this file.
 
 #### haros analyse -r
 
@@ -231,6 +250,10 @@ directories within the given directory.
 Export visualisation files along with analysis data.
 **Existing files on this directory will be removed under some circumstances.**
 
+#### haros export -p PROJECT_NAME
+
+Export a specific project's data, instead of the default one.
+
 
 ### haros viz
 
@@ -245,7 +268,7 @@ Launches the web visualiser and the visualisation server at `localhost:8080`.
 
 Launches the web visusaliser and the visualisation server at the given host.
 
-#### haros viz -d DIR
+#### haros viz -t TARGET_DIR
 
 Serve the given directory, instead of the default one.
 

--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ Either of the following commands will install HAROS for you.
 After installation, you should be able to run the command ``haros`` in
 your terminal from anywhere.
 
-Prerequisites
-~~~~~~~~~~~~~
+Requirements
+~~~~~~~~~~~~
 
 Before you can actually run analyses with HAROS, you need to perform
 some initialisation operations. These operations include downloading a
@@ -104,7 +104,8 @@ Usage
 Here is a basic example to help you get started with HAROS. Additional
 examples should be added in a future update.
 
-HAROS works with the concept of **index files**. These files tell HAROS
+HAROS works with the concept of **index files**. These files are more
+or less an equivalent to a project description, and they tell HAROS
 which packages you want to analyse. For this basic example, you should
 have the packages installed, and with available source code. If you run
 ``rospack find my_package`` and it returns the location of your
@@ -148,6 +149,20 @@ When the analysis finishes, HAROS should start a visualisation server
 and your web browser on the appropriate page. To exit, just close your
 browser and press ``Enter`` on the terminal.
 
+If you want to analyse several projects, or groups of packages, it is
+recommended to create an index file for each project, and define a project
+name as well. This way, HAROS will store analysis results separately.
+Example:
+
+.. code:: yaml
+
+    %YAML 1.1
+    ---
+    project: my_robot
+    packages:
+        - package1
+        - package2
+
 Below you can find the basic commands that HAROS provides.
 
 haros init
@@ -173,6 +188,12 @@ haros analyse -p INDEX_FILE
 
 Uses the given index file to run the analysis, instead of the default
 one.
+
+haros analyse -a ANALYSIS_DB_FILE
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Uses the given analysis database to run the analysis.
+New analysis records are added to this file.
 
 haros analyse -r
 ^^^^^^^^^^^^^^^^
@@ -243,6 +264,11 @@ haros export -v
 Export visualisation files along with analysis data.
 **Existing files on this directory will be removed under some circumstances.**
 
+haros export -p PROJECT_NAME
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Export a specific project's data, instead of the default one.
+
 haros viz
 ~~~~~~~~~
 
@@ -261,8 +287,8 @@ haros viz -s HOST:PORT
 Launches the web visusaliser and the visualisation server at the given
 host.
 
-haros viz -d DIR
-^^^^^^^^^^^^^^^^
+haros viz -t TARGET_DIR
+^^^^^^^^^^^^^^^^^^^^^^^
 
 Serve the given directory, instead of the default one.
 

--- a/haros/data_manager.py
+++ b/haros/data_manager.py
@@ -550,6 +550,7 @@ class Project(AnalysisScope):
 # Object to store and manage all data
 class DataManager(object):
     def __init__(self):
+        self.project        = None
         self.launch_files   = []
         self.repositories   = {}
         self.packages       = {}
@@ -619,6 +620,7 @@ class DataManager(object):
                 data = yaml.load(handle)
         else:
             data = { "packages": [] }
+        self.project = Project(data.get("project", "default"))
     # Step 1: find packages locally
         _log.info("Looking for packages locally.")
         missing = []
@@ -635,6 +637,8 @@ class DataManager(object):
             else:
                 SourceFile.populate_package(pkg, self.files)
                 self.packages[id] = pkg
+                self.project.packages.append(pkg)
+                pkg.project = self.project
     # Step 2: load repositories only if explicitly told to
         _log.debug("Missing packages: %s", missing)
         if index_repos:
@@ -677,6 +681,8 @@ class DataManager(object):
                             missing.remove(id)
                             repo.packages.append(pkg)
                             pkg.repository = repo
+                            self.project.packages.append(pkg)
+                            pkg.project = self.project
                         else:
                             _log.debug("%s was not found in clones.", id)
     # Step 5: sort packages in topological order

--- a/haros/export_manager.py
+++ b/haros/export_manager.py
@@ -30,6 +30,14 @@ _log = logging.getLogger(__name__)
 # Public Functions
 ################################################################################
 
+def export_projects(datadir, projects):
+    _log.info("Exporting project data.")
+    out = os.path.join(datadir, "projects.json")
+    s = "[" + ", ".join([_project_json(p) for p in projects]) + "]"
+    with open(out, "w") as f:
+        _log.debug("Writing to %s", out)
+        f.write(s)
+
 def export_packages(datadir, packages):
     _log.info("Exporting package data.")
     out = os.path.join(datadir, "packages.json")
@@ -224,6 +232,13 @@ def _summary_communications(packages):
         "services":     None,
         "actions":      None
     }
+
+def _project_json(project):
+    s = '{"id": "' + project.id + '", '
+    s += '"packages": '
+    s += json.dumps([p.id for p in project.packages])
+    s += '}'
+    return s
 
 def _pkg_json(pkg):
     s = '{"id": "' + pkg.id + '", '

--- a/haros/haros.py
+++ b/haros/haros.py
@@ -194,12 +194,11 @@ def _check_haros_directory():
 
 def _empty_dir(dir_path):
     _log.debug("Emptying directory %s", dir_path)
-    if os.path.isdir(dir_path):
-        for f in os.listdir(dir_path):
-            path = os.path.join(dir_path, f)
-            if os.path.isfile(path):
-                _log.debug("Removing file %s", path)
-                os.unlink(path)
+    for f in os.listdir(dir_path):
+        path = os.path.join(dir_path, f)
+        if os.path.isfile(path):
+            _log.debug("Removing file %s", path)
+            os.unlink(path)
 
 def command_init(args):
     print "[HAROS] Creating directories..."
@@ -316,17 +315,10 @@ def command_export(args, dataman = None, anaman = None):
     if dataman:
         _log.debug("Exporting on-memory data manager.")
         json_path   = os.path.join(viz_data_dir, dataman.project.name)
-        csv_path    = EXPORT_DIR
+        # csv_path    = EXPORT_DIR
         db_path     = None
         ana_path    = None
-        if not os.path.isdir(json_path):
-            os.mkdir(json_path)
-            os.mkdir(os.path.join(json_path, "compliance"))
-            os.mkdir(os.path.join(json_path, "metrics"))
-            os.mkdir(os.path.join(json_path, "models"))
-        _empty_dir(os.path.join(json_path, "compliance"))
-        _empty_dir(os.path.join(json_path, "metrics"))
-        _empty_dir(os.path.join(json_path, "models"))
+        expoman.export_projects(viz_data_dir, [dataman.project])
     else:
         _log.debug("Exporting data manager from file.")
         if os.path.isfile(DB_PATH):
@@ -341,17 +333,19 @@ def command_export(args, dataman = None, anaman = None):
             return False
         if args.export_viz:
             json_path = os.path.join(viz_data_dir, dataman.project.name)
+            expoman.export_projects(viz_data_dir, [dataman.project])
         else:
             json_path = os.path.join(args.target_dir, "json")
-        if not os.path.exists(json_path):
-            _log.info("Creating directory %s", json_path)
-            os.mkdir(json_path)
-        csv_path = os.path.join(args.target_dir, "csv")
-        if not os.path.exists(csv_path):
-            _log.info("Creating directory %s", csv_path)
-            os.mkdir(csv_path)
+            expoman.export_projects(json_path, [dataman.project])
+        # csv_path = os.path.join(args.target_dir, "csv")
         db_path = os.path.join(args.target_dir, "haros.db")
         ana_path = os.path.join(args.target_dir, "analysis.db")
+    if not os.path.exists(json_path):
+        _log.info("Creating directory %s", json_path)
+        os.mkdir(json_path)
+    # if not os.path.exists(csv_path):
+        # _log.info("Creating directory %s", csv_path)
+        # os.mkdir(csv_path)
     expoman.export_packages(json_path, dataman.packages)
     expoman.export_rules(json_path, dataman.rules)
     expoman.export_metrics(json_path, dataman.metrics)
@@ -360,16 +354,22 @@ def command_export(args, dataman = None, anaman = None):
     if not os.path.exists(path):
         _log.info("Creating directory %s", path)
         os.mkdir(path)
+    else:
+        _empty_dir(path)
     expoman.export_violations(path, dataman.packages)
     path = os.path.join(json_path, "metrics")
     if not os.path.exists(path):
         _log.info("Creating directory %s", path)
         os.mkdir(path)
+    else:
+        _empty_dir(path)
     expoman.export_measurements(path, dataman.packages)
     path = os.path.join(json_path, "models")
     if not os.path.exists(path):
         _log.info("Creating directory %s", path)
         os.mkdir(path)
+    else:
+        _empty_dir(path)
     expoman.export_configurations(path, dataman.packages)
     if db_path:
         _log.debug("Copying data DB from %s to %s", DB_PATH, db_path)

--- a/haros/visualiser.py
+++ b/haros/visualiser.py
@@ -67,12 +67,6 @@ def install(dst, source_runner):
         copy_tree(src, dst)
         _log.info("Creating %s", data_dir)
         os.mkdir(data_dir)
-        _log.info("Creating %s", os.path.join(data_dir, "compliance"))
-        os.mkdir(os.path.join(data_dir, "compliance"))
-        _log.info("Creating %s", os.path.join(data_dir, "metrics"))
-        os.mkdir(os.path.join(data_dir, "metrics"))
-        _log.info("Creating %s", os.path.join(data_dir, "models"))
-        os.mkdir(os.path.join(data_dir, "models"))
 
 
 def serve(directory, host_str):

--- a/harosviz/css/style.css
+++ b/harosviz/css/style.css
@@ -295,6 +295,14 @@ html, body {
 
 
 
+#dashboard-project-select {
+    outline: none;
+    border: none;
+    box-shadow: none;
+    font-weight: bold;
+    color: steelblue;
+}
+
 #dashboard .panel {
     position: relative;
     border-radius: 4px;

--- a/harosviz/index.html
+++ b/harosviz/index.html
@@ -71,6 +71,13 @@ THE SOFTWARE.
     <!-- App Body -->
     <div id="app">
         <section id="dashboard">
+            <div class="margin-h">
+                <label for="dashboard-project-select">
+                    <i class="fa fa-briefcase"></i>
+                    <strong class="show-inline-sm">Project</strong>
+                </label>
+                <select id="dashboard-project-select"></select>
+            </div>
             <div class="pure-g">
                 <div class="pure-u-1 pure-u-sm-1-2 pure-u-lg-1-4">
                     <div id="dashboard-panel-source" class="panel">

--- a/harosviz/js/app.js
+++ b/harosviz/js/app.js
@@ -38,35 +38,33 @@ This script creates the views with the document nodes, and the models from data.
     var App = window.App = {
         Views: {},
         Models: {},
+        project: null, // current project
         board: null, // current view
         rules: null,
+        projects: null,
         packages: null,
         summary: null,
-        violations: null
+        violations: null,
+        configurations: null
     };
 
     $(document).ready(function () {
         delete window.App;
 
         App.rules = new App.Models.RuleCollection();
+        App.projects = new App.Models.ProjectCollection();
         App.packages = new App.Models.PackageCollection();
         App.summary = new App.Models.Summary();
         App.violations = new App.Models.ViolationCollection();
+        App.configurations = new App.Models.ConfigurationCollection();
 
         $(window).resize(_.debounce(onResize, 100));
 
         bootstrapViews();
         Backbone.history.start();
-        preloadData();
+        App.projects.fetch();
     });
 
-
-
-    function preloadData() {
-        App.rules.fetch();
-        App.packages.fetch();
-        App.summary.fetch();
-    }
 
 
     function bootstrapViews() {
@@ -76,14 +74,18 @@ This script creates the views with the document nodes, and the models from data.
         App.preloader = new App.Views.Preloader({
             el: $("#preloader"),
             model: App.summary,
+            projects: App.projects,
             packages: App.packages,
             rules: App.rules,
-            violations: App.violations
+            violations: App.violations,
+            configurations: App.configurations
         });
         App.dashboard = new App.Views.Dashboard({
             el: $("#dashboard"),
-            model: App.summary
+            model: App.summary,
+            projects: App.projects
         });
+        App.dashboard.on("change:project", onProjectSelect);
         App.packageBoard = new App.Views.PackageBoard({
             el: $("#package-board"),
             collection: App.packages,
@@ -92,14 +94,14 @@ This script creates the views with the document nodes, and the models from data.
         });
         App.issueBoard = new App.Views.IssueBoard({
             el: $("#issue-board"),
-            collection: new App.Models.ViolationCollection(),
+            collection: App.violations,
             packages: App.packages,
             rules: App.rules,
             router: App.router
         });
         App.rosBoard = new App.Views.RosBoard({
             el: $("#ros-board"),
-            collection: new App.Models.ConfigurationCollection(),
+            collection: App.configurations,
             packages: App.packages,
             router: App.router
         });
@@ -114,6 +116,19 @@ This script creates the views with the document nodes, and the models from data.
         App.issueBoard.hide();
         App.rosBoard.hide();
         App.helpBoard.hide();
+    }
+
+
+    function onProjectSelect(projectId) {
+        App.project = App.projects.get(projectId);
+        App.rules.projectId = projectId;
+        App.rules.fetch();
+        App.packages.projectId = projectId;
+        App.packages.fetch();
+        App.summary.projectId = projectId;
+        App.summary.fetch();
+        App.violations.projectId = projectId;
+        App.configurations.projectId = projectId;
     }
 
 

--- a/harosviz/js/models.js
+++ b/harosviz/js/models.js
@@ -67,7 +67,31 @@ THE SOFTWARE.
     Models.PackageCollection = Backbone.Collection.extend({
         model: Models.Package,
 
-        url: "data/packages.json"
+        url: function () {
+            return "data/" + this.projectId + "/packages.json";
+        }
+    });
+
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    /*
+        id,
+        packages: []
+    */
+    Models.Project = Backbone.Model.extend({
+        defaults: function () {
+            return {
+                id:         "default",
+                packages:   []
+            }
+        }
+    });
+
+    Models.ProjectCollection = Backbone.Collection.extend({
+        model: Models.Project,
+
+        url: "data/projects.json"
     });
 
 
@@ -102,7 +126,9 @@ THE SOFTWARE.
     Models.RuleCollection = Backbone.Collection.extend({
         model: Models.Rule,
 
-        url: "data/rules.json",
+        url: function () {
+            return "data/" + this.projectId + "/rules.json";
+        },
 
         filterByTags: function (tags) {
             if (tags.length === 0)
@@ -140,7 +166,7 @@ THE SOFTWARE.
         model: Models.Violation,
 
         url: function () {
-            return "data/compliance/" + this.packageId + ".json";
+            return "data/" + this.projectId + "/compliance/" + this.packageId + ".json";
         },
 
         filterByRules: function (rules, ignore) {
@@ -190,7 +216,7 @@ THE SOFTWARE.
         model: Models.Configuration,
 
         url: function () {
-            return "data/models/" + this.packageId + ".json";
+            return "data/" + this.projectId + "/models/" + this.packageId + ".json";
         }
     });
 
@@ -237,6 +263,8 @@ THE SOFTWARE.
         }
     */
     Models.Summary = Backbone.Model.extend({
-        url: "data/summary.json"
+        url: function () {
+            return "data/" + this.projectId + "/summary.json";
+        }
     });
 })();

--- a/harosviz/js/routes.js
+++ b/harosviz/js/routes.js
@@ -43,7 +43,7 @@ THE SOFTWARE.
             dashboard: function() {
                 if (App.board != null) App.board.hide();
                 App.navigation.goTo("dashboard");
-                App.dashboard.show().build();
+                App.dashboard.show().build(App.project);
                 App.board = App.dashboard;
             },
 
@@ -55,25 +55,31 @@ THE SOFTWARE.
             },
 
             packages: function() {
+                if (App.project == null)
+                    return App.router.navigate("dashboard", { trigger: true });
                 if (App.board != null) App.board.hide();
                 App.navigation.goTo("packages");
-                App.packageBoard.show().build();
+                App.packageBoard.show().build(App.project);
                 App.board = App.packageBoard;
             },
 
             issues: function(pkg, page) {
                 // ? query is category/filter (standards, metrics...) ?
                 // maybe keep "resolved" issues from last run?
+                if (App.project == null)
+                    return App.router.navigate("dashboard", { trigger: true });
                 if (App.board != null) App.board.hide();
                 App.navigation.goTo("issues");
-                App.issueBoard.show().build(pkg, page);
+                App.issueBoard.show().build(App.project, pkg, page);
                 App.board = App.issueBoard;
             },
 
             components: function(pkg) {
+                if (App.project == null)
+                    return App.router.navigate("dashboard", { trigger: true });
                 if (App.board != null) App.board.hide();
                 App.navigation.goTo("ros");
-                App.rosBoard.show().build(pkg);
+                App.rosBoard.show().build(App.project, pkg);
                 App.board = App.rosBoard;
             }
         });

--- a/harosviz/js/views/components.js
+++ b/harosviz/js/views/components.js
@@ -36,6 +36,7 @@ THE SOFTWARE.
         },
 
         initialize: function (options) {
+            this.projectId = null;
             this.packageId = null;
             this.packages = options.packages;
             this.router = options.router;
@@ -75,7 +76,8 @@ THE SOFTWARE.
             this.$nodes.append(this.nodeTemplate(data));
         },
 
-        build: function (packageId) {
+        build: function (project, packageId) {
+            this.projectId = project.id;
             this.packageId = packageId;
             this.$summary.html("Select a configuration to display.");
             this.$nodes.hide();

--- a/harosviz/js/views/general.js
+++ b/harosviz/js/views/general.js
@@ -97,17 +97,23 @@ THE SOFTWARE.
 
         initialize: function (options) {
             this.loading = 0;
+            this.projects = options.projects;
             this.packages = options.packages;
             this.rules = options.rules;
             this.violations = options.violations;
+            this.configurations = options.configurations;
             this.listenTo(this.model, "request", this.onRequest);
             this.listenTo(this.model, "sync", this.onSync);
+            this.listenTo(this.projects, "request", this.onRequest);
+            this.listenTo(this.projects, "sync", this.onSync);
             this.listenTo(this.packages, "request", this.onRequest);
             this.listenTo(this.packages, "sync", this.onSync);
             this.listenTo(this.rules, "request", this.onRequest);
             this.listenTo(this.rules, "sync", this.onSync);
             this.listenTo(this.violations, "request", this.onRequest);
             this.listenTo(this.violations, "sync", this.onSync);
+            this.listenTo(this.configurations, "request", this.onRequest);
+            this.listenTo(this.configurations, "sync", this.onSync);
         },
 
         onRequest: function (model_or_collection, xhr, options) {

--- a/harosviz/js/views/issues.js
+++ b/harosviz/js/views/issues.js
@@ -42,6 +42,7 @@ THE SOFTWARE.
 
         initialize: function (options) {
             this.page = 1;
+            this.projectId = null;
             this.packageId = null;
             this.packages = options.packages;
             this.rules = options.rules;
@@ -95,8 +96,9 @@ THE SOFTWARE.
             this.$explorer.append(this.violationTemplate(data));
         },
 
-        build: function (packageId, page) {
+        build: function (project, packageId, page) {
             // save arguments to show later, in case the packages are not loaded
+            this.projectId = project.id;
             this.packageId = packageId;
             this.page = page ? +page || 1 : 1;
             if (this.publicVars.tags != null) {

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extra_files.append("*.yaml")
 
 setup(
     name            = "haros",
-    version         = "0.3.0",
+    version         = "1.0.0",
     author          = "Andre Santos",
     author_email    = "andre.f.santos@inesctec.pt",
     description     = "Static analysis framework for ROS.",


### PR DESCRIPTION
Index files can now specify a project name. This lets HAROS store analysis history data separately, per project. When not specified, all data falls into the *default* project.

*HAROSviz* has been updated to let the user select the current project.