### PR TITLE
Partial support for Image Transport and Message Filters

### DIFF
--- a/haros/analysis_manager.py
+++ b/haros/analysis_manager.py
@@ -366,6 +366,8 @@ class AnalysisManager(LoggingObject):
         reports = {}
         self.report = AnalysisReport(project)
         for pkg in project.packages:
+            if not pkg._analyse:
+                continue
             pkg_report = PackageAnalysis(pkg)
             self.report.by_package[pkg.id] = pkg_report
             reports[pkg.id] = pkg_report
@@ -394,10 +396,14 @@ class AnalysisManager(LoggingObject):
                     iface._plugin = plugin
                     iface.state = plugin.analysis.state
                     for pkg in self.report.project.packages:
+                        if not pkg._analyse:
+                            continue
                         for scope in pkg.source_files:
                             iface._report = iface._reports[scope.id]
                             plugin.analysis.analyse_file(iface, scope)
                     for scope in self.report.project.packages:
+                        if not scope._analyse:
+                            continue
                         iface._report = iface._reports[scope.id]
                         plugin.analysis.analyse_package(iface, scope)
                     for scope in self.report.project.configurations:
@@ -420,12 +426,16 @@ class AnalysisManager(LoggingObject):
                     iface._plugin = plugin
                     iface.state = plugin.process.state
                     for pkg in self.report.project.packages:
+                        if not pkg._analyse:
+                            continue
                         for scope in pkg.source_files:
                             iface._report = iface._reports[scope.id]
                             plugin.process.process_file(iface, scope,
                                     iface._report.violations,
                                     iface._report.metrics)
                     for scope in self.report.project.packages:
+                        if not scope._analyse:
+                            continue
                         iface._report = iface._reports[scope.id]
                         plugin.process.process_package(iface, scope,
                                 iface._report.violations,

--- a/haros/config_builder.py
+++ b/haros/config_builder.py
@@ -292,6 +292,13 @@ class LaunchScope(LoggingObject):
                 links.append(TopicPrimitive(self.node, new, rtype, call_name,
                                             queue, conditions = conditions,
                                             location = source_location))
+        elif rosname.is_unresolved:
+            for topic in collection.get_all(rosname.full):
+                if topic.type == rtype:
+                    links.append(TopicPrimitive(self.node, topic, rtype,
+                            call_name, queue, conditions = conditions,
+                            location = source_location))
+                    break
         else:
             topic = collection.get(rosname.full)
             if not topic is None:
@@ -329,6 +336,13 @@ class LaunchScope(LoggingObject):
                 links.append(ServicePrimitive(self.node, srv, rtype, call_name,
                                               conditions = conditions,
                                               location = source_location))
+        elif rosname.is_unresolved:
+            for srv in collection.get_all(rosname.full):
+                if srv.type == rtype:
+                    links.append(ServicePrimitive(self.node, srv, rtype,
+                            call_name, conditions = conditions,
+                            location = source_location))
+                    break
         else:
             srv = collection.get(rosname.full)
             if not srv is None:

--- a/haros/config_builder.py
+++ b/haros/config_builder.py
@@ -44,6 +44,7 @@ import yaml
 
 rosparam = None # lazy import
 
+from .extractor import HardcodedNodeParser
 from .launch_parser import SubstitutionError, SubstitutionParser
 from .metamodel import (
     Node, Configuration, RosName, NodeInstance, Parameter, Topic, Service,
@@ -851,7 +852,10 @@ class ConfigurationBuilder(LoggingObject):
         node = self.sources.nodes.get("node:" + pkg + "/" + exe)
         package = self.sources.packages.get("package:" + pkg)
         if not package:
-            raise ConfigurationError("cannot find package: " + pkg)
+            assert not node
+            node = HardcodedNodeParser.get(pkg, exe)
+            if not node:
+                raise ConfigurationError("cannot find package: " + pkg)
         if not node:
             node = Node(exe, package, rosname = RosName("?"), nodelet = exe)
         return node

--- a/haros/config_builder.py
+++ b/haros/config_builder.py
@@ -111,6 +111,8 @@ class LaunchScope(LoggingObject):
         ns = self._namespace(ns)
         name = name or node.rosname.own
         rosname = RosName(name, ns, self.private_ns)
+        self.log.debug("Creating NodeInstance %s for Node %s.",
+                       rosname.full, node.name)
         instance = NodeInstance(self.configuration, rosname, node,
                                 launch = self.launch_file, argv = args,
                                 remaps = dict(self.remaps),
@@ -130,6 +132,7 @@ class LaunchScope(LoggingObject):
         for param in self._params:
             rosname = RosName(param.rosname.given, pns, pns)
             conditions = param.conditions + instance.conditions
+            self.log.debug("Creating new forward Parameter %s.", rosname.full)
             param = Parameter(self.configuration, rosname, param.type,
                               param.value, node_scope = param.node_scope,
                               launch = param.launch_file,
@@ -206,21 +209,25 @@ class LaunchScope(LoggingObject):
         pns = self.private_ns
         advertise = advertise or ()
         subscribe = subscribe or ()
+        self.log.debug("Iterating advertise calls for node %s.", self.node.id)
         for call in self.node.node.advertise:
             for link in self._make_topic_links(call.name, call.namespace, pns,
                                                call.type, call.queue_size,
                                                call.conditions, advertise,
                                                call.location):
+                self.log.debug("Linking %s to %s.", self.node.id, link.topic.id)
                 self.node.publishers.append(link)
                 link.topic.publishers.append(link)
                 self._update_topic_conditions(link.topic)
                 if not call.repeats:
                     break
+        self.log.debug("Iterating subscribe calls for node %s.", self.node.id)
         for call in self.node.node.subscribe:
             for link in self._make_topic_links(call.name, call.namespace, pns,
                                                call.type, call.queue_size,
                                                call.conditions, subscribe,
                                                call.location):
+                self.log.debug("Linking %s to %s.", self.node.id, link.topic.id)
                 self.node.subscribers.append(link)
                 link.topic.subscribers.append(link)
                 self._update_topic_conditions(link.topic)
@@ -232,21 +239,25 @@ class LaunchScope(LoggingObject):
         pns = self.private_ns
         service = service or ()
         client = client or ()
+        self.log.debug("Iterating Srv server calls for node %s.", self.node.id)
         for call in self.node.node.service:
             for link in self._make_service_links(call.name, call.namespace,
                                                  pns, call.type,
                                                  call.conditions, service,
                                                  call.location):
+                self.log.debug("Linking %s to %s.", self.node.id, link.service.id)
                 self.node.servers.append(link)
                 link.service.server = link
                 self._update_service_conditions(link.service)
                 if not call.repeats:
                     break
+        self.log.debug("Iterating Srv client calls for node %s.", self.node.id)
         for call in self.node.node.client:
             for link in self._make_service_links(call.name, call.namespace,
                                                  pns, call.type,
                                                  call.conditions, client,
                                                  call.location):
+                self.log.debug("Linking %s to %s.", self.node.id, link.service.id)
                 self.node.clients.append(link)
                 link.service.clients.append(link)
                 self._update_service_conditions(link.service)
@@ -276,38 +287,51 @@ class LaunchScope(LoggingObject):
         collection = self.configuration.topics
         call_name = RosName(name, ns or self.namespace, pns)
         rosname = RosName(name, self.resolve_ns(ns), pns, self.node.remaps)
+        self.log.debug("Finding topic links for %s (%s).",
+                       call_name.full, rosname.full)
         links = []
         if rosname.is_unresolved and hints:
-            pattern = rosname.pattern
-            topics = self._pattern_match(pattern, rtype, collection)
+            # We should only try to unify unresolved names with
+            # names provided by hints. If there is a hint that matches
+            # the name pattern, message type and primitive type, merge.
+            self.log.debug("Processing unresolved name with hints.")
+            topics = self._pattern_match(rosname.pattern, rtype, hints)
             for topic in topics:
-                links.append(TopicPrimitive(self.node, topic, rtype, call_name,
-                                            queue, conditions = conditions,
-                                            location = source_location))
-            topics = self._pattern_match(pattern, rtype, hints)
-            for topic in topics:
+                self.log.debug("Found link to %s from hints.", topic.id)
                 new = topic.remap(RosName(topic.rosname.full,
                                           remaps = self.node.remaps))
                 if new.id in collection:
-                    continue # already done in the step above
-                collection.add(new)
+                    self.log.debug("Reusing Topic from collection.")
+                    new = collection.get(new.rosname.full)
+                    assert not new is None
+                else:
+                    self.log.debug("Creating a new Topic from hints: %s",
+                                   new.rosname.full)
+                    collection.add(new)
                 links.append(TopicPrimitive(self.node, new, rtype, call_name,
                                             queue, conditions = conditions,
                                             location = source_location))
         elif rosname.is_unresolved:
+            # This branch is needed to unify unresolved resources with
+            # the same message type.
+            self.log.debug("Processing unresolved name without hints.")
             for topic in collection.get_all(rosname.full):
                 if topic.type == rtype:
+                    self.log.debug("Found link to %s.", topic.id)
                     links.append(TopicPrimitive(self.node, topic, rtype,
                             call_name, queue, conditions = conditions,
                             location = source_location))
                     break
         else:
+            self.log.debug("Processing resolved name.")
             topic = collection.get(rosname.full)
             if not topic is None:
+                self.log.debug("Found topic %s within collection.", topic.id)
                 links.append(TopicPrimitive(self.node, topic, rtype, call_name,
                                             queue, conditions = conditions,
                                             location = source_location))
         if not links:
+            self.log.debug("No links were found. Creating new topic.")
             topic = Topic(self.configuration, rosname, message_type = rtype)
             collection.add(topic)
             links.append(TopicPrimitive(self.node, topic, rtype, call_name,
@@ -320,38 +344,49 @@ class LaunchScope(LoggingObject):
         collection = self.configuration.services
         call_name = RosName(name, ns or self.namespace, pns)
         rosname = RosName(name, self.resolve_ns(ns), pns, self.node.remaps)
+        self.log.debug("Finding service links for %s (%s).",
+                       call_name.full, rosname.full)
         links = []
         if rosname.is_unresolved and hints:
-            pattern = rosname.pattern
-            services = self._pattern_match(pattern, rtype, collection)
+            # We should only try to unify unresolved names with
+            # names provided by hints. If there is a hint that matches
+            # the name pattern, message type and primitive type, merge.
+            self.log.debug("Processing unresolved name with hints.")
+            services = self._pattern_match(rosname.pattern, rtype, hints)
             for srv in services:
-                links.append(ServicePrimitive(self.node, srv, rtype, call_name,
-                                              conditions = conditions,
-                                              location = source_location))
-            services = self._pattern_match(pattern, rtype, hints)
-            for srv in services:
+                self.log.debug("Found link to %s from hints.", srv.id)
                 new = srv.remap(RosName(srv.rosname.full,
                                         remaps = self.node.remaps))
                 if new.id in collection:
-                    continue # already done in the step above
-                collection.add(new)
+                    self.log.debug("Reusing Service from collection.")
+                    new = collection.get(new.rosname.full)
+                    assert not new is None
+                else:
+                    self.log.debug("Creating a new Service from hints: %s",
+                                   new.rosname.full)
+                    collection.add(new)
                 links.append(ServicePrimitive(self.node, srv, rtype, call_name,
                                               conditions = conditions,
                                               location = source_location))
         elif rosname.is_unresolved:
+            self.log.debug("Processing unresolved name without hints.")
             for srv in collection.get_all(rosname.full):
                 if srv.type == rtype:
+                    self.log.debug("Found link to %s.", srv.id)
                     links.append(ServicePrimitive(self.node, srv, rtype,
                             call_name, conditions = conditions,
                             location = source_location))
                     break
         else:
+            self.log.debug("Processing resolved name.")
             srv = collection.get(rosname.full)
             if not srv is None:
+                self.log.debug("Found service %s within collection.", srv.id)
                 links.append(ServicePrimitive(self.node, srv, rtype, call_name,
                                               conditions = conditions,
                                               location = source_location))
         if not links:
+            self.log.debug("No links were found. Creating new service.")
             srv = Service(self.configuration, rosname, message_type = rtype)
             collection.add(srv)
             links.append(ServicePrimitive(self.node, srv, rtype, call_name,
@@ -621,11 +656,26 @@ class ConfigurationHints(LoggingObject):
         pns = scope.private_ns
         for topic in self.advertise:
             self.log.debug("hint topic %s", topic.rosname.full)
+            remap_name = scope.node.remaps.get(topic.rosname.full,
+                                               topic.rosname.full)
             for link in scope.node.publishers:
-                if link.topic == topic:
-                    self.log.debug("%s (%s) is already extracted",
-                                   link.topic.rosname.full, link.topic.type)
-                    break # TODO what about different types?
+                if link.topic.rosname.full == remap_name:
+                    if link.topic.type is None:
+                        self.log.debug("Refining %s with type %s.",
+                                       link.topic.rosname.full, topic.type)
+                        link.topic.type = topic.type
+                    elif link.topic.type != topic.type:
+                        self.log.warning(("Extraction hint for node %s "
+                                          "advertises topic %s (%s), "
+                                          "but extractor found %s (%s)."),
+                                         scope.node.id,
+                                         topic.id, topic.type,
+                                         link.topic.id, link.topic.type)
+                        break
+                    else:
+                        self.log.debug("%s (%s) is already extracted",
+                                       link.topic.rosname.full, link.topic.type)
+                        break
             else:
                 for link in scope._make_topic_links(topic.rosname.full,
                                                     scope.namespace, pns,
@@ -636,11 +686,26 @@ class ConfigurationHints(LoggingObject):
                     link.topic.conditions.extend(link.node.conditions)
         for topic in self.subscribe:
             self.log.debug("hint topic %s", topic.rosname.full)
+            remap_name = scope.node.remaps.get(topic.rosname.full,
+                                               topic.rosname.full)
             for link in scope.node.subscribers:
-                if link.topic == topic:
-                    self.log.debug("%s (%s) is already extracted",
-                                   link.topic.rosname.full, link.topic.type)
-                    break
+                if link.topic.rosname.full == remap_name:
+                    if link.topic.type is None:
+                        self.log.debug("Refining %s with type %s.",
+                                       link.topic.rosname.full, topic.type)
+                        link.topic.type = topic.type
+                    elif link.topic.type != topic.type:
+                        self.log.warning(("Extraction hint for node %s "
+                                          "subscribes topic %s (%s), "
+                                          "but extractor found %s (%s)."),
+                                         scope.node.id,
+                                         topic.id, topic.type,
+                                         link.topic.id, link.topic.type)
+                        break
+                    else:
+                        self.log.debug("%s (%s) is already extracted",
+                                       link.topic.rosname.full, link.topic.type)
+                        break
             else:
                 for link in scope._make_topic_links(topic.rosname.full,
                                                     scope.namespace, pns,
@@ -651,11 +716,26 @@ class ConfigurationHints(LoggingObject):
                     link.topic.conditions.extend(link.node.conditions)
         for service in self.service:
             self.log.debug("hint service %s", service.rosname.full)
+            remap_name = scope.node.remaps.get(service.rosname.full,
+                                               service.rosname.full)
             for link in scope.node.servers:
-                if link.service == service:
-                    self.log.debug("%s (%s) is already extracted",
-                                   link.service.rosname.full, link.service.type)
-                    break
+                if link.service.rosname.full == remap_name:
+                    if link.service.type is None:
+                        self.log.debug("Refining %s with type %s.",
+                                       link.service.rosname.full, service.type)
+                        link.service.type = service.type
+                    elif link.service.type != service.type:
+                        self.log.warning(("Extraction hint for node %s "
+                                          "advertises service %s (%s), "
+                                          "but extractor found %s (%s)."),
+                                         scope.node.id,
+                                         service.id, service.type,
+                                         link.service.id, link.service.type)
+                        break
+                    else:
+                        self.log.debug("%s (%s) is already extracted",
+                                       link.service.rosname.full, link.service.type)
+                        break
             else:
                 for link in scope._make_service_links(service.rosname.full,
                                                       scope.namespace, pns,
@@ -666,11 +746,26 @@ class ConfigurationHints(LoggingObject):
                     link.service.conditions.extend(link.node.conditions)
         for service in self.client:
             self.log.debug("hint service %s", service.rosname.full)
+            remap_name = scope.node.remaps.get(service.rosname.full,
+                                               service.rosname.full)
             for link in scope.node.clients:
-                if link.service == service:
-                    self.log.debug("%s (%s) is already extracted",
-                                   link.service.rosname.full, link.service.type)
-                    break
+                if link.service.rosname.full == remap_name:
+                    if link.service.type is None:
+                        self.log.debug("Refining %s with type %s.",
+                                       link.service.rosname.full, service.type)
+                        link.service.type = service.type
+                    elif link.service.type != service.type:
+                        self.log.warning(("Extraction hint for node %s "
+                                          "is client of service %s (%s), "
+                                          "but extractor found %s (%s)."),
+                                         scope.node.id,
+                                         service.id, service.type,
+                                         link.service.id, link.service.type)
+                        break
+                    else:
+                        self.log.debug("%s (%s) is already extracted",
+                                       link.service.rosname.full, link.service.type)
+                        break
             else:
                 for link in scope._make_service_links(service.rosname.full,
                                                       scope.namespace, pns,

--- a/haros/export_manager.py
+++ b/haros/export_manager.py
@@ -74,8 +74,8 @@ class JsonExporter(LoggingObject):
             packages = packages.viewvalues()
         with open(out, "w") as f:
             self.log.debug("Writing to %s", out)
-            json.dump([self._pkg_analysis_JSON(pkg) for pkg in packages], f,
-                      indent=2, separators=(",", ":"))
+            json.dump([self._pkg_analysis_JSON(pkg) for pkg in packages],
+                      f, indent=2, separators=(",", ":"))
 
     def export_rules(self, datadir, rules):
         self.log.info("Exporting analysis rules.")

--- a/haros/export_manager.py
+++ b/haros/export_manager.py
@@ -197,24 +197,31 @@ class JsonExporter(LoggingObject):
         if isinstance(obj, Resource) and obj.configuration == config:
              return {
                 "name": obj.id,
+                "uid": str(id(obj)),
                 "resourceType": obj.resource_type
             }
         elif isinstance(obj, TopicPrimitive) and obj.configuration == config:
             return {
                 "node": obj.node.id,
+                "node_uid": str(id(obj.node)),
                 "topic": obj.topic.id,
+                "topic_uid": str(id(obj.topic)),
                 "resourceType": "link"
             }
         elif isinstance(obj, ServicePrimitive) and obj.configuration == config:
             return {
                 "node": obj.node.id,
+                "node_uid": str(id(obj.node)),
                 "service": obj.service.id,
+                "service_uid": str(id(obj.service)),
                 "resourceType": "link"
             }
         elif isinstance(obj, ParameterPrimitive) and obj.configuration == config:
             return {
                 "node": obj.node.id,
+                "node_uid": str(id(obj.node)),
                 "param": obj.parameter.id,
+                "param_uid": str(id(obj.parameter)),
                 "resourceType": "link"
             }
         return None
@@ -224,6 +231,7 @@ class JsonExporter(LoggingObject):
         data = {
             "id": pkg.name,
             "metapackage": pkg.is_metapackage,
+            "version": pkg.version,
             "description": pkg.description,
             "wiki": pkg.website,
             "repository": pkg.vcs_url,

--- a/haros/extractor.py
+++ b/haros/extractor.py
@@ -627,6 +627,9 @@ class PackageParser(LoggingObject):
             elif value == "bugtracker":
                 if el.text:
                     package.bug_url = el.text.strip()
+        el = xml.find("version")
+        if not el is None:
+            package.version = el.text.strip()
 
     @staticmethod
     def _parse_export(xml, package):

--- a/haros/extractor.py
+++ b/haros/extractor.py
@@ -729,45 +729,47 @@ class HardcodedNodeParser(LoggingObject):
                         nodelet = node_type if node_data["nodelet"] else None)
         for datum in node_data.get("advertise", ()):
             pub = Publication(datum["name"], datum["namespace"],
-                              datum["type"], datum["queue"],
-                              control_depth = datum["depth"],
-                              repeats = datum["repeats"],
-                              conditions = datum["conditions"])
+                    datum["type"], datum["queue"],
+                    control_depth = datum["depth"],
+                    repeats = datum["repeats"],
+                    conditions = [SourceCondition(c)
+                                  for c in datum["conditions"]])
             node.advertise.append(pub)
         for datum in node_data.get("subscribe", ()):
             sub = Subscription(datum["name"], datum["namespace"],
-                              datum["type"], datum["queue"],
-                              control_depth = datum["depth"],
-                              repeats = datum["repeats"],
-                              conditions = datum["conditions"])
+                    datum["type"], datum["queue"],
+                    control_depth = datum["depth"],
+                    repeats = datum["repeats"],
+                    conditions = [SourceCondition(c)
+                                  for c in datum["conditions"]])
             node.subscribe.append(sub)
         for datum in node_data.get("service", ()):
             srv = ServiceServerCall(datum["name"], datum["namespace"],
-                                    datum["type"],
-                                    control_depth = datum["depth"],
-                                    repeats = datum["repeats"],
-                                    conditions = datum["conditions"])
+                    datum["type"], control_depth = datum["depth"],
+                    repeats = datum["repeats"],
+                    conditions = [SourceCondition(c)
+                                  for c in datum["conditions"]])
             node.service.append(srv)
         for datum in node_data.get("client", ()):
             cli = ServiceClientCall(datum["name"], datum["namespace"],
-                                    datum["type"],
-                                    control_depth = datum["depth"],
-                                    repeats = datum["repeats"],
-                                    conditions = datum["conditions"])
+                    datum["type"], control_depth = datum["depth"],
+                    repeats = datum["repeats"],
+                    conditions = [SourceCondition(c)
+                                  for c in datum["conditions"]])
             node.client.append(cli)
         for datum in node_data.get("readParam", ()):
             par = ReadParameterCall(datum["name"], datum["namespace"],
-                                    datum["type"],
-                                    control_depth = datum["depth"],
-                                    repeats = datum["repeats"],
-                                    conditions = datum["conditions"])
+                    datum["type"], control_depth = datum["depth"],
+                    repeats = datum["repeats"],
+                    conditions = [SourceCondition(c)
+                                  for c in datum["conditions"]])
             node.read_param.append(par)
         for datum in node_data.get("writeParam", ()):
             par = WriteParameterCall(datum["name"], datum["namespace"],
-                                    datum["type"],
-                                    control_depth = datum["depth"],
-                                    repeats = datum["repeats"],
-                                    conditions = datum["conditions"])
+                    datum["type"], control_depth = datum["depth"],
+                    repeats = datum["repeats"],
+                    conditions = [SourceCondition(c)
+                                  for c in datum["conditions"]])
             node.write_param.append(par)
         return node
 

--- a/haros/metamodel.py
+++ b/haros/metamodel.py
@@ -834,6 +834,7 @@ class NodeInstance(Resource):
 
     def to_JSON_object(self):
         return {
+            "uid": str(id(self)),
             "name": self.id,
             "type": self.node.node_name,
             "args": self.argv,
@@ -891,6 +892,7 @@ class Topic(Resource):
 
     def to_JSON_object(self):
         return {
+            "uid": str(id(self)),
             "name": self.id,
             "type": self.type,
             "conditions": [c.to_JSON_object() for c in self.conditions],
@@ -956,6 +958,7 @@ class Service(Resource):
 
     def to_JSON_object(self):
         return {
+            "uid": str(id(self)),
             "name": self.id,
             "type": self.type,
             "conditions": [c.to_JSON_object() for c in self.conditions],
@@ -1031,6 +1034,7 @@ class Parameter(Resource):
 
     def to_JSON_object(self):
         return {
+            "uid": str(id(self)),
             "name": self.id,
             "type": self.type,
             "value": self.value,
@@ -1070,6 +1074,14 @@ class ResourceCollection(object):
                 if conditional or not resource.conditions:
                     return resource
         return None
+
+    def get_all(self, name, conditional = True):
+        resources = []
+        for resource in self.all:
+            if resource.id == name:
+                if conditional or not resource.conditions:
+                    resources.append(resource)
+        return resources
 
     def get_collisions(self):
         return len(self.all) - len(self.counter)
@@ -1186,6 +1198,7 @@ class RosPrimitive(MetamodelObject):
     def to_JSON_object(self):
         return {
             "node": self.node.rosname.full,
+            "node_uid": str(id(self.node)),
             "name": self.rosname.full,
             "location": (self.source_location.to_JSON_object()
                          if self.source_location else None),
@@ -1209,6 +1222,7 @@ class TopicPrimitive(RosPrimitive):
     def to_JSON_object(self):
         data = RosPrimitive.to_JSON_object(self)
         data["topic"] = self.topic_name
+        data["topic_uid"] = str(id(self.topic))
         data["type"] = self.type
         data["queue"] = self.queue_size
         return data
@@ -1264,6 +1278,7 @@ class ServicePrimitive(RosPrimitive):
     def to_JSON_object(self):
         data = RosPrimitive.to_JSON_object(self)
         data["service"] = self.topic_name
+        data["service_uid"] = str(id(self.service))
         data["type"] = self.type
         return data
 
@@ -1318,6 +1333,7 @@ class ParameterPrimitive(RosPrimitive):
     def to_JSON_object(self):
         data = RosPrimitive.to_JSON_object(self)
         data["param"] = self.param_name
+        data["param_uid"] = str(id(self.parameter))
         data["type"] = self.type
         return data
 

--- a/haros/metamodel.py
+++ b/haros/metamodel.py
@@ -249,6 +249,7 @@ class SourceObject(MetamodelObject):
         self.id = id
         self.name = name
         self.dependencies = DependencySet()
+        self._analyse = True
 
     @property
     def location(self):

--- a/haros/metamodel.py
+++ b/haros/metamodel.py
@@ -391,6 +391,7 @@ class Package(SourceObject):
         self.maintainers        = set()
         self.is_metapackage     = False
         self.description        = ""
+        self.version            = "0.0.0"
         self.licenses           = set()
         self.website            = None
         self.vcs_url            = None
@@ -435,6 +436,7 @@ class Package(SourceObject):
             "name": self.name,
             "metapackage": self.is_metapackage,
             "description": self.description,
+            "version": self.version,
             "wiki": self.website,
             "repository": self.vcs_url,
             "bugTracker": self.bug_url,

--- a/haros/models/controller_manager.yaml
+++ b/haros/models/controller_manager.yaml
@@ -1,0 +1,82 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+# TODO: incomplete
+indigo:
+    spawner:
+        nodelet: false
+        advertise: []
+        subscribe:
+            -
+                name: "?"
+                type: std_msgs/Bool
+                namespace: ""
+                queue: 1
+                depth: 1
+                location: null
+                repeats: false
+                conditions: ["if wait_for_topic"]
+        service: []
+        client:
+            -
+                name: "controller_manager/load_controller"
+                type: controller_manager_msgs/LoadController
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "controller_manager/switch_controller"
+                type: controller_manager_msgs/SwitchController
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "controller_manager/unload_controller"
+                type: controller_manager_msgs/UnloadController
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        readParam: []
+        writeParam:
+            -
+                name: "?"
+                type: object
+                default: {}
+                namespace: ""
+                depth: 2
+                location: null
+                repeats: true
+                conditions: ["for name in args.controllers", "if os.path.exists(name)"]
+kinetic:
+    spawner:
+        base: indigo
+lunar:
+    spawner:
+        base: indigo
+melodic:
+    spawner:
+        base: indigo

--- a/haros/models/diagnostic_aggregator.yaml
+++ b/haros/models/diagnostic_aggregator.yaml
@@ -1,0 +1,93 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    aggregator_node:
+        nodelet: false
+        advertise:
+            -
+                name: "/diagnostics_agg"
+                type: diagnostic_msgs/DiagnosticArray
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "/diagnostics_toplevel_state"
+                type: diagnostic_msgs/DiagnosticStatus
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "/diagnostics"
+                type: diagnostic_msgs/DiagnosticArray
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "pub_rate"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "base_path"
+                type: string
+                default: ""
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "analyzers"
+                type: object
+                default: {}
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    aggregator_node:
+        base: indigo
+lunar:
+    aggregator_node:
+        base: indigo
+melodic:
+    aggregator_node:
+        base: indigo

--- a/haros/models/hector_mapping.yaml
+++ b/haros/models/hector_mapping.yaml
@@ -1,0 +1,300 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+# TODO: incomplete
+indigo:
+    hector_mapping:
+        nodelet: false
+        advertise:
+            -
+                name: "map_metadata"
+                type: nav_msgs/MapMetaData
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map"
+                type: nav_msgs/OccupancyGrid
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "slam_out_pose"
+                type: geometry_msgs/PoseStamped
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "poseupdate"
+                type: geometry_msgs/PoseWithCovarianceStamped
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "scan"
+                type: sensor_msgs/LaserScan
+                namespace: ""
+                queue: null
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "syscommand"
+                type: std_msgs/String
+                namespace: ""
+                queue: 2
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service:
+            -
+                name: "dynamic_map"
+                type: nav_msgs/GetMap
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        client: []
+        readParam:
+            -
+                name: "base_frame"
+                type: string
+                default: "base_link"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_frame"
+                type: string
+                default: "map_link"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "odom_frame"
+                type: string
+                default: "odom"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_resolution"
+                type: double
+                default: 0.025
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_size"
+                type: int
+                default: 1024
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_start_x"
+                type: double
+                default: 0.5
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_start_y"
+                type: double
+                default: 0.5
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_update_distance_thresh"
+                type: double
+                default: 0.4
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_update_angle_thresh"
+                type: double
+                default: 0.9
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_pub_period"
+                type: double
+                default: 2.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_multi_res_levels"
+                type: int
+                default: 3
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "update_factor_free"
+                type: double
+                default: 0.4
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "update_factor_occupied"
+                type: double
+                default: 0.9
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "laser_min_dist"
+                type: double
+                default: 0.4
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "laser_max_dist"
+                type: double
+                default: 30.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "laser_z_min_value"
+                type: double
+                default: -1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "laser_z_max_value"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "pub_map_odom_transform"
+                type: bool
+                default: true
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "output_timing"
+                type: bool
+                default: false
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "scan_subscriber_queue_size"
+                type: int
+                default: 5
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "pub_map_scanmatch_transform"
+                type: bool
+                default: true
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "tf_map_scanmatch_transform_frame_name"
+                type: string
+                default: "scanmatcher_frame"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    hector_mapping:
+        base: indigo
+lunar:
+    hector_mapping:
+        base: indigo
+melodic:
+    hector_mapping:
+        base: indigo

--- a/haros/models/husky_base.yaml
+++ b/haros/models/husky_base.yaml
@@ -1,0 +1,120 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    husky_node:
+        nodelet: false
+        advertise:
+            -
+                name: "husky_velocity_controller/odom"
+                type: nav_msgs/Odometry
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "status"
+                type: husky_msgs/HuskyStatus
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "husky_velocity_controller/cmd_vel"
+                type: geometry_msgs/Twist
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "control_frequency"
+                type: double
+                default: 10.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "diagnostic_frequency"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "wheel_diameter"
+                type: double
+                default: 0.3555
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "max_accel"
+                type: double
+                default: 3.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "max_speed"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "port"
+                type: string
+                default: "/dev/prolific"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    husky_node:
+        base: indigo
+lunar:
+    husky_node:
+        base: indigo
+melodic:
+    husky_node:
+        base: indigo

--- a/haros/models/interactive_marker_twist_server.yaml
+++ b/haros/models/interactive_marker_twist_server.yaml
@@ -1,0 +1,75 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    marker_server:
+        nodelet: false
+        advertise:
+            -
+                name: "cmd_vel"
+                type: geometry_msgs/Twist
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "link_name"
+                type: string
+                default: "/base_link"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "robot_name"
+                type: string
+                default: "robot"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "marker_size_scale"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    marker_server:
+        base: indigo
+lunar:
+    marker_server:
+        base: indigo
+melodic:
+    marker_server:
+        base: indigo

--- a/haros/models/interactive_marker_twist_server.yaml
+++ b/haros/models/interactive_marker_twist_server.yaml
@@ -26,7 +26,7 @@ indigo:
             -
                 name: "cmd_vel"
                 type: geometry_msgs/Twist
-                namespace: ""
+                namespace: "~"
                 queue: 1
                 depth: 0
                 location: null

--- a/haros/models/joy.yaml
+++ b/haros/models/joy.yaml
@@ -1,0 +1,84 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    joy_node:
+        nodelet: false
+        advertise:
+            -
+                name: "joy"
+                type: sensor_msgs/Joy
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "dev"
+                type: string
+                default: "/dev/input/js0"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "deadzone"
+                type: double
+                default: 0.05
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "autorepeat_rate"
+                type: double
+                default: 0.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "coalesce_interval"
+                type: double
+                default: 0.001
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    joy_node:
+        base: indigo
+lunar:
+    joy_node:
+        base: indigo
+melodic:
+    joy_node:
+        base: indigo

--- a/haros/models/lms1xx.yaml
+++ b/haros/models/lms1xx.yaml
@@ -1,0 +1,66 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    LMS1xx_node:
+        nodelet: false
+        advertise:
+            -
+                name: "scan"
+                type: sensor_msgs/LaserScan
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "host"
+                type: string
+                default: "192.168.1.2"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "frame_id"
+                type: string
+                default: "laser"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    LMS1xx_node:
+        base: indigo
+lunar:
+    LMS1xx_node:
+        base: indigo
+melodic:
+    LMS1xx_node:
+        base: indigo

--- a/haros/models/move_base.yaml
+++ b/haros/models/move_base.yaml
@@ -1,0 +1,225 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    move_base:
+        nodelet: false
+        advertise:
+            -
+                name: "cmd_vel"
+                type: geometry_msgs/Twist
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "move_base_simple/goal"
+                type: geometry_msgs/PoseStamped
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service:
+            -
+                name: "make_plan"
+                type: nav_msgs/GetPlan
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "clear_unknown_space"
+                type: std_srvs/Empty
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "clear_costmaps"
+                type: std_srvs/Empty
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        client: []
+        actionServer:
+            -
+                name: "move_base"
+                type: move_base_msgs/MoveBaseAction
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        readParam:
+            -
+                name: "base_global_planner"
+                type: string
+                default: "navfn/NavfnROS"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "base_local_planner"
+                type: string
+                default: "base_local_planner/TrajectoryPlannerROS"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "recovery_behaviors"
+                type: list
+                default:
+                    -
+                        name: conservative_reset
+                        type: clear_costmap_recovery/ClearCostmapRecovery
+                    -
+                        name: rotate_recovery
+                        type: rotate_recovery/RotateRecovery
+                    -
+                        name: aggressive_reset
+                        type: clear_costmap_recovery/ClearCostmapRecovery
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "controller_frequency"
+                type: double
+                default: 20.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "planner_patience"
+                type: double
+                default: 5.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "controller_patience"
+                type: double
+                default: 15.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "conservative_reset_dist"
+                type: double
+                default: 3.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "recovery_behavior_enabled"
+                type: bool
+                default: true
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "clearing_rotation_allowed"
+                type: bool
+                default: true
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "shutdown_costmaps"
+                type: bool
+                default: false
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "oscillation_timeout"
+                type: double
+                default: 0.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "oscillation_distance"
+                type: double
+                default: 0.5
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "planner_frequency"
+                type: double
+                default: 0.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "max_planning_retries"
+                type: int
+                default: -1
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    move_base:
+        base: indigo
+lunar:
+    move_base:
+        base: indigo
+melodic:
+    move_base:
+        base: indigo

--- a/haros/models/prosilica_camera.yaml
+++ b/haros/models/prosilica_camera.yaml
@@ -1,0 +1,89 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    prosilica_node:
+        nodelet: false
+        advertise:
+            -
+                name: "camera/image_raw"
+                type: sensor_msgs/Image
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "camera/camera_info"
+                type: sensor_msgs/CameraInfo
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe: []
+        service:
+            -
+                name: "set_camera_info"
+                type: sensor_msgs/SetCameraInfo
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "request_image"
+                type: polled_camera/GetPolledImage
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        client: []
+        readParam:
+            -
+                name: "ip_address"
+                type: string
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "guid"
+                type: string
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    prosilica_node:
+        base: indigo
+lunar:
+    prosilica_node:
+        base: indigo
+melodic:
+    prosilica_node:
+        base: indigo

--- a/haros/models/robot_localization.yaml
+++ b/haros/models/robot_localization.yaml
@@ -1,0 +1,145 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+# TODO: incomplete
+indigo:
+    ekf_localization_node:
+        nodelet: false
+        advertise:
+            -
+                name: "odometry/filtered"
+                type: nav_msgs/Odometry
+                namespace: ""
+                queue: 20
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "accel/filtered"
+                type: geometry_msgs/AccelWithCovarianceStamped
+                namespace: ""
+                queue: 20
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "set_pose"
+                type: geometry_msgs::PoseWithCovarianceStamped
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "?"
+                type: nav_msgs/Odometry
+                namespace: ""
+                queue: null
+                depth: 3
+                location: null
+                repeats: true
+                conditions: ["if (poseUpdateSum + twistUpdateSum > 0)", "if (moreParams)", "while (moreParams)"]
+        service:
+            -
+                name: "set_pose"
+                type: robot_localization/SetPose
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        client: []
+        readParam:
+            -
+                name: "frequency"
+                type: double
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "sensor_timeout"
+                type: double
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "two_d_mode"
+                type: bool
+                default: false
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "map_frame"
+                type: string
+                default: "map"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "odom_frame"
+                type: string
+                default: "odom"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "base_link_frame"
+                type: string
+                default: "base_link"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "world_frame"
+                type: string
+                default: "odom"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    ekf_localization_node:
+        base: indigo
+lunar:
+    ekf_localization_node:
+        base: indigo
+melodic:
+    ekf_localization_node:
+        base: indigo

--- a/haros/models/robot_state_publisher.yaml
+++ b/haros/models/robot_state_publisher.yaml
@@ -22,7 +22,94 @@
 indigo:
     state_publisher:
         nodelet: false
-        advertise: []
+        advertise:
+            -
+                name: "/tf_static"
+                type: tf2_msgs/TFMessage
+                namespace: ""
+                queue: 100
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "/tf"
+                type: tf2_msgs/TFMessage
+                namespace: ""
+                queue: 100
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "joint_states"
+                type: sensor_msgs/JointState
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "robot_description"
+                type: string
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "tf_prefix"
+                type: string
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "publish_frequency"
+                type: double
+                default: 50
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "use_tf_static"
+                type: bool
+                default: false
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+    robot_state_publisher:
+        nodelet: false
+        advertise:
+            -
+                name: "/tf_static"
+                type: tf2_msgs/TFMessage
+                namespace: ""
+                queue: 100
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "/tf"
+                type: tf2_msgs/TFMessage
+                namespace: ""
+                queue: 100
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
         subscribe:
             -
                 name: "joint_states"
@@ -93,9 +180,34 @@ kinetic:
                 location: null
                 repeats: false
                 conditions: []
+    robot_state_publisher:
+        base: indigo
+        readParam:
+            -
+                name: "use_tf_static"
+                type: bool
+                default: true
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "ignore_timestamp"
+                type: bool
+                default: false
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
 lunar:
     state_publisher:
         base: kinetic
+    robot_state_publisher:
+        base: kinetic
 melodic:
     state_publisher:
+        base: kinetic
+    robot_state_publisher:
         base: kinetic

--- a/haros/models/robot_state_publisher.yaml
+++ b/haros/models/robot_state_publisher.yaml
@@ -1,0 +1,101 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    state_publisher:
+        nodelet: false
+        advertise: []
+        subscribe:
+            -
+                name: "joint_states"
+                type: sensor_msgs/JointState
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "robot_description"
+                type: string
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "tf_prefix"
+                type: string
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "publish_frequency"
+                type: double
+                default: 50
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "use_tf_static"
+                type: bool
+                default: false
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    state_publisher:
+        base: indigo
+        readParam:
+            -
+                name: "use_tf_static"
+                type: bool
+                default: true
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "ignore_timestamp"
+                type: bool
+                default: false
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+lunar:
+    state_publisher:
+        base: kinetic
+melodic:
+    state_publisher:
+        base: kinetic

--- a/haros/models/teleop_twist_joy.yaml
+++ b/haros/models/teleop_twist_joy.yaml
@@ -1,0 +1,120 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    teleop_node:
+        nodelet: false
+        advertise:
+            -
+                name: "cmd_vel"
+                type: geometry_msgs/Twist
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe:
+            -
+                name: "joy"
+                type: sensor_msgs/Joy
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "enable_button"
+                type: int
+                default: 0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "enable_turbo_button"
+                type: int
+                default: -1
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "axis_linear"
+                type: int
+                default: 1
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "scale_linear"
+                type: double
+                default: 0.5
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "scale_linear_turbo"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "axis_angular"
+                type: int
+                default: 0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+            -
+                name: "scale_angular"
+                type: double
+                default: 1.0
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    teleop_node:
+        base: indigo
+lunar:
+    teleop_node:
+        base: indogo
+melodic:
+    teleop_node:
+        base: indigo

--- a/haros/models/template.yaml
+++ b/haros/models/template.yaml
@@ -1,0 +1,68 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    node_type:
+        rosname: null
+        nodelet: false
+        advertise: []
+        subscribe:
+            -
+                name: "topic_name"
+                type: std_msgs/Int32
+                namespace: ""
+                queue: 1
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        service: []
+        client: []
+        readParam:
+            -
+                name: "param_name"
+                type: string
+                default: "value"
+                namespace: "~"
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        writeParam: []
+kinetic:
+    node_type:
+        base: indigo
+        readParam:
+            -
+                name: "another_param"
+                type: bool
+                default: true
+                namespace: ""
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+lunar:
+    node_type:
+        base: kinetic
+melodic:
+    node_type:
+        base: kinetic

--- a/haros/models/tf.yaml
+++ b/haros/models/tf.yaml
@@ -1,0 +1,48 @@
+%YAML 1.1
+#Copyright (c) 2018 Andre Santos
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files (the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following conditions:
+
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the Software.
+
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
+---
+indigo:
+    static_transform_publisher:
+        nodelet: false
+        advertise:
+            -
+                name: "/tf_static"
+                type: tf2_msgs/TFMessage
+                namespace: ""
+                queue: 100
+                depth: 0
+                location: null
+                repeats: false
+                conditions: []
+        subscribe: []
+        service: []
+        client: []
+        readParam: []
+        writeParam: []
+kinetic:
+    static_transform_publisher:
+        base: indigo
+lunar:
+    static_transform_publisher:
+        base: indigo
+melodic:
+    static_transform_publisher:
+        base: indigo

--- a/harosviz/index.html
+++ b/harosviz/index.html
@@ -550,12 +550,14 @@ THE SOFTWARE.
             for (var i = 0; i < data.conditions.length; ++i)
                 print('<br/><span class="code">' + data.conditions[i].condition
                       + "</span> in <i>"
-                      + data.conditions[i].location.package
-                      + (data.conditions[i].location.file
-                         ? "/" + data.conditions[i].location.file : "")
-                      + "</i>"
-                      + (data.conditions[i].location.line
-                         ? ", line " + data.conditions[i].location.line : "")
+                      + (data.conditions[i].location
+                        ? (data.conditions[i].location.package
+                            + (data.conditions[i].location.file
+                                ? "/" + data.conditions[i].location.file : "")
+                            + "</i>"
+                            + (data.conditions[i].location.line
+                                ? ", line " + data.conditions[i].location.line : ""))
+                        : "unknown location</i>")
                       + "\n");
             %>
         </p>

--- a/harosviz/js/models.js
+++ b/harosviz/js/models.js
@@ -203,6 +203,7 @@ THE SOFTWARE.
         collisions,
         remaps,
         nodes: [{
+            uid,
             name,
             type,
             args,
@@ -218,6 +219,7 @@ THE SOFTWARE.
             writes: []
         }],
         topics: [{
+            uid,
             name,
             type,
             conditions: [{
@@ -228,6 +230,7 @@ THE SOFTWARE.
             subscribers: []
         }],
         services: [{
+            uid,
             name,
             type,
             conditions: [{
@@ -238,6 +241,7 @@ THE SOFTWARE.
             clients: []
         }],
         parameters: [{
+            uid,
             name,
             type,
             value,
@@ -251,7 +255,9 @@ THE SOFTWARE.
         links: {
             publishers: [{
                 node,
+                node_uid,
                 topic,
+                topic_uid,
                 type,
                 queue,
                 name,
@@ -260,7 +266,9 @@ THE SOFTWARE.
             }],
             subscribers: [{
                 node,
+                node_uid,
                 topic,
+                topic_uid,
                 type,
                 queue,
                 name,
@@ -269,7 +277,9 @@ THE SOFTWARE.
             }],
             servers: [{
                 node,
+                node_uid,
                 service,
+                service_uid,
                 type,
                 name,
                 location: {},
@@ -277,7 +287,9 @@ THE SOFTWARE.
             }],
             clients: [{
                 node,
+                node_uid,
                 service,
+                service_uid,
                 type,
                 name,
                 location: {},
@@ -285,7 +297,9 @@ THE SOFTWARE.
             }],
             reads: [{
                 node,
+                node_uid,
                 param,
+                param_uid,
                 type,
                 name,
                 location: {},
@@ -293,7 +307,9 @@ THE SOFTWARE.
             }],
             writes: [{
                 node,
+                node_uid,
                 param,
+                param_uid,
                 type,
                 name,
                 location: {},
@@ -305,7 +321,12 @@ THE SOFTWARE.
             name,
             objects: [{
                 name,
-                resourceType
+                resourceType,
+                uid?,
+                node_uid?,
+                topic_uid?,
+                service_uid?,
+                param_uid?
             }]
         }]
     */

--- a/harosviz/js/views/ros.js
+++ b/harosviz/js/views/ros.js
@@ -587,8 +587,8 @@ THE SOFTWARE.
         onDrag: function (node) {
             if (this.allowDrag) {
                 var i, edges = this.graph.nodeEdges(node.model.id);
-                node.x = node.dragx;
-                node.y = node.dragy;
+                node.x = Math.ceil(node.dragx / 16.0) * 16;
+                node.y = Math.ceil(node.dragy / 16.0) * 16;
                 node.render();
                 for (i = edges.length; i--;)
                     this.graph.edge(edges[i]).render();

--- a/harosviz/js/views/ros.js
+++ b/harosviz/js/views/ros.js
@@ -331,45 +331,45 @@ THE SOFTWARE.
             this.listenTo(view, "selected", this.onSelection);
             this.listenTo(view, "drag", this.onDrag);
             this.graph.setNode(model.id, view);
-            mapping[resource.name] = model;
+            mapping[resource.uid] = model;
         },
 
         addPublisher: function (link) {
-            var topic = this.topics[link.topic];
+            var topic = this.topics[link.topic_uid];
             topic.get("types")[link.type] = true;
-            this._addEdge(this.nodes[link.node].id, topic.id, !!link.conditions.length);
+            this._addEdge(this.nodes[link.node_uid].id, topic.id, !!link.conditions.length);
         },
 
         addSubscriber: function (link) {
-            var topic = this.topics[link.topic];
+            var topic = this.topics[link.topic_uid];
             topic.get("types")[link.type] = true;
-            this._addEdge(topic.id, this.nodes[link.node].id, !!link.conditions.length);
+            this._addEdge(topic.id, this.nodes[link.node_uid].id, !!link.conditions.length);
         },
 
         addClient: function (link) {
-            var service = this.services[link.service];
+            var service = this.services[link.service_uid];
             service.get("types")[link.type] = true;
-            this._addEdge(this.nodes[link.node].id, service.id, !!link.conditions.length);
+            this._addEdge(this.nodes[link.node_uid].id, service.id, !!link.conditions.length);
         },
 
         addServer: function (link) {
-            var service = this.services[link.service];
+            var service = this.services[link.service_uid];
             service.get("types")[link.type] = true;
-            this._addEdge(service.id, this.nodes[link.node].id, !!link.conditions.length);
+            this._addEdge(service.id, this.nodes[link.node_uid].id, !!link.conditions.length);
         },
 
         addWrite: function (link) {
-            var param = this.params[link.param];
+            var param = this.params[link.param_uid];
             if (link.type != null)
                 param.get("types")[link.type] = true;
-            this._addEdge(this.nodes[link.node].id, param.id, !!link.conditions.length);
+            this._addEdge(this.nodes[link.node_uid].id, param.id, !!link.conditions.length);
         },
 
         addRead: function (link) {
-            var param = this.params[link.param];
+            var param = this.params[link.param_uid];
             if (link.type != null)
                 param.get("types")[link.type] = true;
-            this._addEdge(param.id, this.nodes[link.node].id, !!link.conditions.length);
+            this._addEdge(param.id, this.nodes[link.node_uid].id, !!link.conditions.length);
         },
 
         _addEdge: function (sourceCid, targetCid, conditional) {
@@ -472,22 +472,22 @@ THE SOFTWARE.
                 obj = objs[i];
                 switch (obj.resourceType) {
                     case "node":
-                        this.graph.node(this.nodes[obj.name].id).queries[query.rule] = true;
+                        this.graph.node(this.nodes[obj.uid].id).queries[query.rule] = true;
                         break;
                     case "topic":
-                        this.graph.node(this.topics[obj.name].id).queries[query.rule] = true;
+                        this.graph.node(this.topics[obj.uid].id).queries[query.rule] = true;
                         break;
                     case "service":
-                        this.graph.node(this.services[obj.name].id).queries[query.rule] = true;
+                        this.graph.node(this.services[obj.uid].id).queries[query.rule] = true;
                         break;
                     case "param":
-                        this.graph.node(this.params[obj.name].id).queries[query.rule] = true;
+                        this.graph.node(this.params[obj.uid].id).queries[query.rule] = true;
                         break;
                     case "link":
-                        n1 = this.nodes[obj.node].id;
-                        n2 = (this.topics[obj.topic]
-                              || this.services[obj.service]
-                              || this.params[obj.param]).id;
+                        n1 = this.nodes[obj.node_uid].id;
+                        n2 = (this.topics[obj.topic_uid]
+                              || this.services[obj.service_uid]
+                              || this.params[obj.param_uid]).id;
                         v = this.graph.edge(n1, n2) || this.graph.edge(n2, n1);
                         v.queries[query.rule] = true;
                         break;

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ def package_files(directory):
 
 extra_files = package_files("harosviz")
 extra_files.append("*.yaml")
+extra_files.append("models/*.yaml")
 
 
 setup(


### PR DESCRIPTION
- Fixed a bug in the model extraction process, where too many links between nodes and topics were generated.
- The model extractor now unifies multiple unresolved topics with the same message type.
- The model extractor only replaces unresolved topics with topics from user-provided hints.
- Dependency packages and launch files are loaded lazily.
- Added a work-in-progress database of pre-parsed nodes for distribution packages.
- Added partial support to extract `message_filters::Subscriber`, `image_transport::Publisher` and `image_transport::SubscriberFilter`.
- Fixed a crash that would occur when running haros from source code.
- Added a unique ID to exported JSON entities of the extracted models.