### PR TITLE
Find workspace built with catkin_make_isolated

### DIFF
--- a/haros/data.py
+++ b/haros/data.py
@@ -496,6 +496,11 @@ class HarosSettings(object):
                 if (path.endswith(os.sep + "devel")
                         or path.endswith(os.sep + "install")):
                     return os.path.abspath(os.path.join(path, os.pardir))
+                elif ("devel_isolated" in path
+                        or "install_isolated" in path):
+                    # CMAKE_PREFIX_PATH point at the devel_isolated/package path
+                    # in workspaces built with catkin_make_isolated.
+                    return os.path.abspath(os.path.join(path, os.pardir, os.pardir))
         raise KeyError("ROS_WORKSPACE")
 
 


### PR DESCRIPTION
As part of our work proposed in https://github.com/ros-infrastructure/ros_buildfarm/issues/596 we would like to make use of haros for packages defined as a `catkin test`. Please see https://github.com/ipa-jfh/haros_catkin as an example.

The scripts running the `devel` jobs on the [buildfarm](https://github.com/ros-infrastructure/ros_buildfarm/blob/1d99c76f36a5ff2825c348e7de32dc2256dbdd53/scripts/devel/build_and_test.py) make use of `catkin_make_isolated` and as such I would prefer to extend `haros` to run in a workspace built with `catkin_make_isolated`.