### PR TITLE
Optional Dependency on pyflwor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 N/A
 
+## [3.1.1] - 2019-03-04
+### Changed
+- Made the dependency on `pyflwor` optional (#38).
+- Updated README to reflect this (#40).
+
 ## [3.1.0] - 2019-01-30
 ### Added
 - HAROS can now detect workspaces built with `catkin_make_isolated` and `catkin build`.

--- a/README.md
+++ b/README.md
@@ -89,24 +89,24 @@ from anywhere.
 
 ### Requirements
 
-Before you can actually run analyses with HAROS, you need to perform some
-initialisation operations. These operations include downloading a basic set of
-analysis plugins. Do so with:
-
-```bash
-haros init
-```
-
-**Note:** if you opted for running HAROS without installing it, replace `haros`
-with your preferred method.
-
-After initialisation, you still need to install some analysis tools that HAROS
+Before running any kind of analysis, you need to install some analysis tools that HAROS
 uses behind the curtains. Install these *$dependencies$* with the following commands.
 
 ```bash
 [sudo] apt-get install cppcheck
 [sudo] apt-get install cccc
+```
+
+Optionally, install `pyflwor` to enable queries to run on extracted models later on.
+
+```bash
 pip install -e git+https://github.com/timtadh/pyflwor.git#egg=pyflwor
+```
+
+or, if you have a `virtualenv`
+
+```bash
+pip install pyflwor-ext
 ```
 
 If you want to use the model extraction features of HAROS, you must install
@@ -129,6 +129,17 @@ If you do not perform this step and your library is installed in a different pat
 you will need to specify it in the configuration file located in
 `~/.haros/index.yaml`. This file becomes available after running the
 `init` command of HAROS (details below).
+
+Finally, you need to perform some initialisation operations.
+These operations include downloading a basic set of analysis plugins.
+Do so with:
+
+```bash
+haros init
+```
+
+**Note:** if you opted for running HAROS without installing it, replace `haros`
+with your preferred method.
 
 HAROS is now installed and ready to use.
 

--- a/haros/analysis_manager.py
+++ b/haros/analysis_manager.py
@@ -29,8 +29,6 @@ import os
 import shutil
 import traceback
 
-import pyflwor
-
 from .metamodel import MetamodelObject, Location, RuntimeLocation
 from .data import (
     Violation, Measurement, FileAnalysis, PackageAnalysis,
@@ -381,6 +379,13 @@ class AnalysisManager(LoggingObject):
         return reports
 
     def _execute_queries(self, reports):
+        self.log.debug("import pyflwor")
+        try:
+            import pyflwor
+        except ImportError as e:
+            self.log.warning("Could not import pyflwor. "
+                             "Skipping query execution.")
+            return
         self.log.debug("Creating query engine.")
         query_engine = QueryEngine(self.database)
         query_engine.execute(self.database.rules.viewvalues(), reports)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extra_files.append("*.yaml")
 
 setup(
     name            = "haros",
-    version         = "3.1.0",
+    version         = "3.1.1",
     author          = "Andre Santos",
     author_email    = "andre.f.santos@inesctec.pt",
     description     = "Static analysis framework for ROS.",


### PR DESCRIPTION
This PR makes it so that HAROS can operate without errors when `pyflwor` is not available.