### PR TITLE
Fixed two bugs (junit_xml_output default value; "py"/"python" as file IDs)

### DIFF
--- a/haros/haros.py
+++ b/haros/haros.py
@@ -425,7 +425,7 @@ class HarosRunner(object):
     """This is a base class for the specific commands that HAROS provides."""
 
     def __init__(self, haros_dir, config_path, log, run_from_source,
-                 junit_xml_output):
+                 junit_xml_output = False):
         self.root               = haros_dir
         self.config_path        = config_path
         self.repo_dir           = os.path.join(haros_dir, "repositories")

--- a/haros/metamodel.py
+++ b/haros/metamodel.py
@@ -376,7 +376,7 @@ class SourceFile(SourceObject):
         if self.name.endswith(self.CPP):
             return "cpp"
         if self.name.endswith(self.PYTHON):
-            return "py"
+            return "python"
         if self.name.endswith(self.LAUNCH):
             return "launch"
         if self.name == self.PKG_XML:
@@ -392,7 +392,7 @@ class SourceFile(SourceObject):
     def _ignore_parsers(self):
         if self.language == "cpp":
             return (_cpp_ignore_line, _cpp_ignore_next_line)
-        elif self.language == "py":
+        elif self.language == "python":
             return (_py_ignore_line, _py_ignore_next_line)
         return (_no_parser, _no_parser)
 


### PR DESCRIPTION
The first bug was introduced in the recent merge of
https://github.com/git-afsantos/haros/pull/79 and involves a missing
default value in the constructor/initializer or HarosRunner
which will break HarosVizRunner.

The other is that python files received the file identifier "py",
but plugins and statistics modules expect the identifyer to be "python".