### PR TITLE
Add python-magic to the requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ bonsai_code>=0.4.10
 setuptools>=20.7.0
 PyYAML>=3.13,<4.0
 haros-plugins>=1.0.3,<2.0.0
+python-magic>=0.4.15
+


### PR DESCRIPTION
Add a missing dependency: python-magic 