### PR TITLE
add ws arg for full option

### DIFF
--- a/haros/haros.py
+++ b/haros/haros.py
@@ -311,6 +311,7 @@ class HarosLauncher(object):
                             help = "load/export using the given directory")
         parser.add_argument("--no-cache", action = "store_true",
                             help = "do not use available caches")
+        parser.add_argument("--ws", help = "set the catkin workspace directory")
         parser.add_argument("--no-write-cache", action = "store_true",
                             help = "do not update parsing cache")
         parser.add_argument("--junit-xml-output", action='store_true',


### PR DESCRIPTION
Current `pip install haros` (or even building from `master` branch) fails at https://github.com/git-afsantos/haros/blob/master/haros/haros.py#L214. Needed this fix to get it working. 