### PR TITLE
fix env reading

### DIFF
--- a/haros/data.py
+++ b/haros/data.py
@@ -547,7 +547,9 @@ class HarosSettings(object):
         if env == "copy" or env == "all" or env is True:
             env = dict(os.environ)
         elif isinstance(env, dict):
-            env = (dict(cls.DEFAULTS["environment"])).update(env)
+            default_env = dict(cls.DEFAULTS["environment"])
+            default_env.update(env)
+            env = default_env
         elif not env is None:
             raise ValueError("invalid value for environment")
         blacklist = data.get("plugin_blacklist", [])


### PR DESCRIPTION
The return value of `dict.update()` is `None`, so calling `env = (dict(cls.DEFAULTS["environment"])).update(env)` only assigns `None` to `env`