### PR TITLE
use utf-8-sig when reading cmakelists to handle bom

### DIFF
--- a/haros/cmake_parser.py
+++ b/haros/cmake_parser.py
@@ -258,7 +258,7 @@ class CMakeParser(object):
         self.parsetree = None
 
     def parse(self, filename):
-        with open(filename, "r") as cmakefile:
+        with open(filename, "r", encoding="utf-8-sig") as cmakefile:
             self.input = ParseInput(cmakefile.read())
         self.parsetree = self.parse_block_children(None)
         if self.parsetree is None:


### PR DESCRIPTION
Some CMakeLists.txt files have BOM at the beginning, like this one: https://raw.githubusercontent.com/ROBOTIS-GIT/turtlebot3_manipulation/master/turtlebot3_manipulation_gui/CMakeLists.txt

Use "utf-8-sig" when opening the file to handle the BOM.

References:
https://www.freecodecamp.org/news/a-quick-tale-about-feff-the-invisible-character-cd25cd4630e7/
https://stackoverflow.com/questions/57152985/what-is-the-difference-between-utf-8-and-utf-8-sig